### PR TITLE
M: Removed https://www.moscarossa.biz/ links hiding (nsfw)

### DIFF
--- a/easylist/easylist_general_hide.txt
+++ b/easylist/easylist_general_hide.txt
@@ -20682,7 +20682,6 @@
 ##a[href^="https://www.iclwy.xyz/"]
 ##a[href^="https://www.im88trk.com/"]
 ##a[href^="https://www.incredimail.com/?id"]
-##a[href^="https://www.moscarossa.biz/"]
 ##a[href^="https://www.mrskin.com/tour"]
 ##a[href^="https://www.mypornstarcams.com/landing/click/"]
 ##a[href^="https://www.nudeidols.com/cams/"]


### PR DESCRIPTION
Hi, I've noticed a strange behavior in some Google search results and decided to investigate it. Every search result for moscarossa.biz is blocked, that's just an example:

<img width="504" alt="Schermata 2020-05-20 alle 13 51 40" src="https://user-images.githubusercontent.com/1315456/82447424-94cf0580-9aa8-11ea-93ac-59b461764356.png">

After some digging I found out that the same goes in many other legit websites (other search engines, directories, forums, blogs...) where links to moscarossa.biz are hidden. So I tracked back the blocking rule and I think it might have been added by mistake?
It's part of this commit 6eb61a06fd724d63d4be3ea3e978c61463ff5d45 and I don't get why it's there. The commit is about some xcafe.com website, but it also adds to easylist_general_hide links to: freeadult.games (I checked and it seems to be some sort of free trial with credit card subscription scam website), track.trkinator.com (no idea what that is, I can't reach the domain), and finally www.moscarossa.biz, which is one of the top 3 escort listing websites in Italy. Escort listing is adult business but is totally legal in Italy and AFAIK there's no reason to ad-block it. I have to admit it's not a good looking website, being https://torino.bakecaincontrii.com/donna-cerca-uomo/ and https://www.escortforumit.xxx their competitor, but still it should be a normal website, no advertising or tracking or something.
Thank you!